### PR TITLE
Add option for custom reporter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,9 +387,9 @@
       }
     },
     "fp-ts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.0.1.tgz",
-      "integrity": "sha512-eYnHWiybaM7oHgV3j22nQ8DJ6JEviYLfXWDE+X6FHsIAFTuJPLiStZD7bDhuU/YR8NLZ/dz7i9NED76L/SbOUw=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.8.1.tgz",
+      "integrity": "sha512-hcNjU4yFw2j0vqqTxJTptHAagA9KN5iaETmYGyMkoQcJzblVWq+7jEJdMy0CfJtVMjzTJn0sZIg+3Rfb+sAy4A=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -518,11 +518,11 @@
       "dev": true
     },
     "io-ts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.0.2.tgz",
-      "integrity": "sha512-AaIObA2fyQtSmKDL9cLoIw8nLTTGYpT05Ax34Xp38SNUmkUQPD05zjKXkVik4wSa4IqiecQWycNpKO4csnEmdw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.3.0.tgz",
+      "integrity": "sha512-3Y+shQijBP4rUpREG26AqumeBncm1ANf0bYeDU9DNb0GE99fhm1S+jk/ZvEd2RV+S8aVLNbXpwWX2+ysuei0QQ==",
       "requires": {
-        "fp-ts": "1.0.1"
+        "fp-ts": "1.8.1"
       }
     },
     "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "prop-types-ts",
   "version": "0.6.0",
   "description": "Alternative syntax for prop types providing both static and runtime type safety, powered by io-ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "tslint src/**/*.ts test/**/*.ts",
     "clean": "rm -rf lib/*",
     "mocha": "TS_NODE_CACHE=false mocha -r ts-node/register test/*.tsx",
-    "prettier":
-      "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",
-    "fix-prettier":
-      "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test}/**/*.ts\"",
+    "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",
+    "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test}/**/*.ts\"",
     "test": "npm run lint && npm run prettier && npm run mocha",
     "build": "npm run clean && tsc"
   },
@@ -41,6 +41,16 @@
     "tslint-config-standard": "^4.0.0",
     "typescript": "2.7.1"
   },
-  "tags": ["typescript", "react", "prop-types", "io-ts"],
-  "keywords": ["typescript", "react", "prop-types", "io-ts"]
+  "tags": [
+    "typescript",
+    "react",
+    "prop-types",
+    "io-ts"
+  ],
+  "keywords": [
+    "typescript",
+    "react",
+    "prop-types",
+    "io-ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/gcanti/prop-types-ts",
   "dependencies": {
-    "io-ts": "^1.0.2",
+    "io-ts": "^1.3.0",
     "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/gcanti/prop-types-ts",
   "dependencies": {
-    "io-ts": "^1.3.0",
+    "io-ts": "^1.0.2",
     "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { ComponentClass } from 'react'
 import * as t from 'io-ts'
 import { PathReporter } from 'io-ts/lib/PathReporter'
+import { Reporter } from 'io-ts/lib/Reporter'
 import * as React from 'react'
 
 // tslint:disable-next-line no-empty
@@ -9,6 +10,7 @@ const noop = () => {}
 export type Options = {
   strict?: boolean
   children?: t.Mixed
+  reporter?: Reporter<string[]>
 }
 
 function getExcessProps(values: Object, props: t.Props): Array<string> {
@@ -64,6 +66,8 @@ function getProps(values: any, type: PropTypeable): t.Props | null {
 }
 
 export function getPropTypes(type: PropTypeable, options: Options = { strict: true }) {
+  const reporter = options.reporter || PathReporter
+
   return {
     __prop_types_ts(values: any, prop: string, displayName: string): Error | null {
       const validation = type.decode(values).chain(v => {
@@ -74,7 +78,7 @@ export function getPropTypes(type: PropTypeable, options: Options = { strict: tr
         }
       })
       return validation.fold(
-        () => new Error('\n' + PathReporter.report(validation).join('\n')),
+        () => new Error('\n' + reporter.report(validation).join('\n')),
         () => {
           const props = options.strict ? getProps(values, type) : null
           if (props) {


### PR DESCRIPTION
For deeply nested types. The path reporter can be a bit verbose. This pull requests allows a reporter class to be specified for the prop types.